### PR TITLE
Cope with there not being a newline after the template (after '}}')

### DIFF
--- a/lib/mediawiki/page.rb
+++ b/lib/mediawiki/page.rb
@@ -55,7 +55,7 @@ module MediaWiki
           \{\{
           (?<template_name>#{Regexp.quote(template)})
           (?<parameters>.*?)
-          \}\}\n
+          \}\}
           (?<after>.*)$
         /xm
       end

--- a/test/mediawiki/page_test.rb
+++ b/test/mediawiki/page_test.rb
@@ -48,6 +48,24 @@ Now let\'s have a recognized template:
 
 But there\'s no terminating HTML comment.'.freeze
 
+WIKITEXT_NOTHING_AFTER_TEMPLATE = 'Hi, here is some introductory text.
+
+Now let\'s have a recognized template:
+
+{{Politician scraper comparison
+|foo=43
+|bar=Woolly Mountain Tapir
+}}'.freeze
+
+WIKITEXT_NO_WHITESPACE_AFTER_TEMPLATE = 'Hi, here is some introductory text.
+
+Now let\'s have a recognized template:
+
+{{Politician scraper comparison
+|foo=43
+|bar=Woolly Mountain Tapir
+}}Hello - this text immediately abuts the template.'.freeze
+
 FakeResponse = Struct.new(:body)
 
 describe 'ReplaceableContent' do
@@ -78,7 +96,7 @@ describe 'ReplaceableContent' do
 
     it 'can return the wikitext within a section' do
       section.existing_content.must_equal(
-        "\nOld content of the first section.\n"
+        "\n\nOld content of the first section.\n"
       )
       client.verify
     end
@@ -159,6 +177,7 @@ Now let\'s have a recognized template:
 New content for the first section!
 <!-- OUTPUT END succeeded -->
 
+
 But there\'s no terminating HTML comment.'
       )
       client.verify
@@ -185,6 +204,7 @@ Now let\'s have a recognized template:
 New content for the first section!
 <!-- OUTPUT END Run time: took absolutely ages -->
 
+
 But there\'s no terminating HTML comment.',
         ]
       )
@@ -193,6 +213,60 @@ But there\'s no terminating HTML comment.',
         'Run time: took absolutely ages'
       )
       client.verify
+    end
+  end
+
+  describe 'no whitespace is found after the template' do
+    let(:wikitext) { WIKITEXT_NO_WHITESPACE_AFTER_TEMPLATE }
+
+    it 'can parse the page and return empty existing content' do
+      section.existing_content.must_equal('')
+    end
+
+    it 'can be reassembled with new content' do
+      section.reassemble_page(
+        'New content here!',
+        'succeeded'
+      ).must_equal(
+        'Hi, here is some introductory text.
+
+Now let\'s have a recognized template:
+
+{{Politician scraper comparison
+|foo=43
+|bar=Woolly Mountain Tapir
+}}
+New content here!
+<!-- OUTPUT END succeeded -->
+Hello - this text immediately abuts the template.'
+      )
+    end
+  end
+
+  describe 'nothing is after the template' do
+    let(:wikitext) { WIKITEXT_NOTHING_AFTER_TEMPLATE }
+
+    it 'can parse the page and return empty existing content' do
+      section.existing_content.must_equal('')
+    end
+
+    it 'can be reassembled with new content' do
+      section.reassemble_page(
+        'New content here!',
+        'succeeded'
+      ).must_equal(
+        'Hi, here is some introductory text.
+
+Now let\'s have a recognized template:
+
+{{Politician scraper comparison
+|foo=43
+|bar=Woolly Mountain Tapir
+}}
+New content here!
+<!-- OUTPUT END succeeded -->
+'
+      )
     end
   end
 end

--- a/test/mediawiki/page_test.rb
+++ b/test/mediawiki/page_test.rb
@@ -51,23 +51,26 @@ But there\'s no terminating HTML comment.'.freeze
 FakeResponse = Struct.new(:body)
 
 describe 'ReplaceableContent' do
+  let(:client) do
+    client = MiniTest::Mock.new
+    client.expect(
+      :get_wikitext,
+      FakeResponse.new(wikitext),
+      ['Some Wiki page']
+    )
+    client
+  end
+
+  let(:section) do
+    MediaWiki::Page::ReplaceableContent.new(
+      client: client,
+      title: 'Some Wiki page',
+      template: 'Politician scraper comparison'
+    )
+  end
+
   describe 'multiple sections with output terminated by HTML comments' do
-    let(:client) do
-      client = MiniTest::Mock.new
-      client.expect(
-        :get_wikitext,
-        FakeResponse.new(WIKITEXT_MULTIPLE_TERMINATED),
-        ['Some Wiki page']
-      )
-      client
-    end
-    let(:section) do
-      MediaWiki::Page::ReplaceableContent.new(
-        client: client,
-        title: 'Some Wiki page',
-        template: 'Politician scraper comparison'
-      )
-    end
+    let(:wikitext) { WIKITEXT_MULTIPLE_TERMINATED }
 
     it 'can be created an non-nill' do
       section.wont_be_nil
@@ -129,22 +132,7 @@ Now some trailing text.
   end
 
   describe 'single section with unterminated output' do
-    let(:client) do
-      client = MiniTest::Mock.new
-      client.expect(
-        :get_wikitext,
-        FakeResponse.new(WIKITEXT_SINGLE_UNTERMINATED),
-        ['Some Wiki page']
-      )
-      client
-    end
-    let(:section) do
-      MediaWiki::Page::ReplaceableContent.new(
-        client: client,
-        title: 'Some Wiki page',
-        template: 'Politician scraper comparison'
-      )
-    end
+    let(:wikitext) { WIKITEXT_SINGLE_UNTERMINATED }
 
     it 'can be created an non-nill' do
       section.wont_be_nil


### PR DESCRIPTION
The regular expression that divides up the page was failing if there was
no whitespace after the template tag. This commit fixes that, so we make
no assumption at all about what follows the template tag. This means
updating some of the test, since there existing text which is considered
to be part of our output will have changed.

Fixes #1