### PR TITLE
Avoid matching {{!}} in template regular expression

### DIFF
--- a/lib/mediawiki/page.rb
+++ b/lib/mediawiki/page.rb
@@ -55,6 +55,7 @@ module MediaWiki
           \{\{
           (?<template_name>#{Regexp.quote(template)})
           (?<parameters>.*?)
+          (?<!\!)
           \}\}
           (?<after>.*)$
         /xm

--- a/test/mediawiki/page_test.rb
+++ b/test/mediawiki/page_test.rb
@@ -66,6 +66,17 @@ Now let\'s have a recognized template:
 |bar=Woolly Mountain Tapir
 }}Hello - this text immediately abuts the template.'.freeze
 
+WIKITEXT_CONTAINS_SUB_TEMPLATE = 'Hi, here is some introductory text.
+
+Now let\'s have a recognized template:
+
+{{Politician scraper comparison
+|foo={{!}}
+|bar=Woolly Mountain Tapir
+}}
+
+But there\'s no terminating HTML comment.'.freeze
+
 FakeResponse = Struct.new(:body)
 
 describe 'ReplaceableContent' do
@@ -267,6 +278,14 @@ New content here!
 <!-- OUTPUT END succeeded -->
 '
       )
+    end
+  end
+
+  describe 'template contains sub-template' do
+    let(:wikitext) { WIKITEXT_CONTAINS_SUB_TEMPLATE }
+
+    it 'returns the correct parameters' do
+      section.params.must_equal(foo: '{{!}}', bar: 'Woolly Mountain Tapir')
     end
   end
 end


### PR DESCRIPTION
This adds a negative lookbehind to the template regular expression which means it will avoid matching `{{!}}` in the middle of the template, which was one of the causes of https://github.com/everypolitician/compare_with_wikidata/issues/40.

While this does fix the immediate problem, it won't handle other sub-templates, so it's certainly not an ideal solution.

Related to #5 