### PR TITLE
Handle anonymous parameters, not just named parameters

### DIFF
--- a/lib/mediawiki/page.rb
+++ b/lib/mediawiki/page.rb
@@ -26,6 +26,17 @@ module MediaWiki
         client.edit(title: title, text: new_wikitext)
       end
 
+      def param_key_value_array(key, value)
+        [
+          if key.strip =~ /^\d+$/
+            Integer(Regexp.last_match[0])
+          else
+            key.strip.to_sym
+          end,
+          value,
+        ]
+      end
+
       def params
         # Returns the named parameters from the template tag as a Hash
         # where the keys are symbolized versions of the parameter
@@ -34,7 +45,7 @@ module MediaWiki
         # returning them.
         all_parameters.map do |p|
           m = NAMED_TEMPLATE_PARAM_RE.match(p)
-          [m[1].strip.to_sym, m[2]] if m
+          param_key_value_array(*m.captures) if m
         end.compact.to_h
       end
 

--- a/lib/mediawiki/page.rb
+++ b/lib/mediawiki/page.rb
@@ -3,6 +3,8 @@ require 'mediawiki_api'
 module MediaWiki
   module Page
     class ReplaceableContent
+      NAMED_TEMPLATE_PARAM_RE = /(.*?)=(.*)/m
+
       def initialize(client:, title:, template:)
         @client = client
         @title = title
@@ -31,9 +33,15 @@ module MediaWiki
         # FIXME: untemplate these using the MediaWiki API before
         # returning them.
         all_parameters.map do |p|
-          m = /(.*?)=(.*)/m.match(p)
-          [m[1].strip.to_sym, m[2]]
-        end.to_h
+          m = NAMED_TEMPLATE_PARAM_RE.match(p)
+          [m[1].strip.to_sym, m[2]] if m
+        end.compact.to_h
+      end
+
+      def anonymous_params
+        # FIXME: untemplate these using the MediaWiki API before
+        # returning them.
+        all_parameters.map { |p| NAMED_TEMPLATE_PARAM_RE =~ p ? nil : p }.compact
       end
 
       private

--- a/mediawiki-page-replaceable_content.gemspec
+++ b/mediawiki-page-replaceable_content.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mediawiki_api', '~> 0.7'
 
   spec.add_development_dependency 'bundler', '~> 1.15'
-  spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rubocop', '~> 0.49'
 end

--- a/test/mediawiki/page_test.rb
+++ b/test/mediawiki/page_test.rb
@@ -75,6 +75,8 @@ Old content of the first section.
 
 <!-- OUTPUT END -->'.freeze
 
+WIKITEXT_SINGLE_POSITIONAL_PARAMETER = '{{Politician scraper comparison|12345}}'.freeze
+
 FakeResponse = Struct.new(:body)
 
 describe 'ReplaceableContent' do
@@ -195,6 +197,10 @@ But there\'s no terminating HTML comment.'
       section.params.must_equal(foo: '43', bar: 'Woolly Mountain Tapir')
     end
 
+    it 'has no anonymous parameters' do
+      section.anonymous_params.must_be_empty
+    end
+
     it 'will post back with the new content and an optional comment on the run' do
       client.expect(
         :edit,
@@ -297,6 +303,18 @@ New content here!
 New content here!
 <!-- OUTPUT END succeeded -->'
       )
+    end
+  end
+
+  describe 'a template with a single positional parameter' do
+    let(:wikitext) { WIKITEXT_SINGLE_POSITIONAL_PARAMETER }
+
+    it 'must return only one anonymous parameter' do
+      section.anonymous_params.must_equal(%w[12345])
+    end
+
+    it 'must not return named parameters' do
+      section.params.must_be_empty
     end
   end
 end

--- a/test/mediawiki/page_test.rb
+++ b/test/mediawiki/page_test.rb
@@ -77,6 +77,10 @@ Old content of the first section.
 
 WIKITEXT_SINGLE_POSITIONAL_PARAMETER = '{{Politician scraper comparison|12345}}'.freeze
 
+WIKITEXT_NUMBERED_PARAMETERS = '{{Politician scraper comparison|1=foo|2=bar|10=baz}}'.freeze
+
+WIKITEXT_CONFUSING_PARAMETER_MIX = '{{Politician scraper comparison|id=42|12345|1=foo|baz=bar|789}}'.freeze
+
 FakeResponse = Struct.new(:body)
 
 describe 'ReplaceableContent' do
@@ -315,6 +319,38 @@ New content here!
 
     it 'must not return named parameters' do
       section.params.must_be_empty
+    end
+  end
+
+  describe 'a template with numbered parameters' do
+    let(:wikitext) { WIKITEXT_NUMBERED_PARAMETERS }
+
+    it 'returns numbered parameters' do
+      section.params.must_equal(
+        1 => 'foo',
+        2 => 'bar',
+        10 => 'baz'
+      )
+    end
+
+    it 'must not return anonymous parameters' do
+      section.anonymous_params.must_be_empty
+    end
+  end
+
+  describe 'a template with a confusing mix of parameters' do
+    let(:wikitext) { WIKITEXT_CONFUSING_PARAMETER_MIX }
+
+    it 'returns both parameters in an array' do
+      section.anonymous_params.must_equal(%w[12345 789])
+    end
+
+    it 'returns the named and numbered parameters' do
+      section.params.must_equal(
+        :id => '42',
+        1 => 'foo',
+        :baz => 'bar'
+      )
     end
   end
 end


### PR DESCRIPTION
Previously if you included an anonymous parameter, e.g. had a template
tag like:

    {{MyAwesomeTemplate|1234}}

... you would just get an exception. This is also common for people to
do when they don't understand that the template is expecting a named
parameter.

This pull request stops that happening, and makes "anonymous parameters" like
these available as and array under the `.anonymous_params` of a section.

It also handles numbered parameters, making their integer value the key in
`.params`.

Fixes #7