### PR TITLE
Add TemplateNotFoundError exception class

### DIFF
--- a/lib/mediawiki/client.rb
+++ b/lib/mediawiki/client.rb
@@ -18,9 +18,7 @@ module MediaWiki
     def wrapped_client
       @wrapped_client ||= MediawikiApi::Client.new("https://#{site}/w/api.php").tap do |c|
         result = c.log_in(username, password)
-        unless result['result'] == 'Success'
-          raise "MediawikiApi::Client#log_in failed: #{result}"
-        end
+        raise "MediawikiApi::Client#log_in failed: #{result}" if result['result'] != 'Success'
       end
     end
   end

--- a/lib/mediawiki/page.rb
+++ b/lib/mediawiki/page.rb
@@ -5,6 +5,8 @@ module MediaWiki
     class ReplaceableContent
       NAMED_TEMPLATE_PARAM_RE = /(.*?)=(.*)/m
 
+      TemplateNotFoundError = Class.new(StandardError)
+
       def initialize(client:, title:, template:)
         @client = client
         @title = title
@@ -81,7 +83,7 @@ module MediaWiki
       def page_parts
         return @page_parts if @page_parts
         m = template_re.match(wikitext)
-        raise "The template '#{template}' was not found in '#{title}'" unless m
+        raise TemplateNotFoundError, "The template '#{template}' was not found in '#{title}'" unless m
         parts = matchdata_to_h(m)
         @page_parts = parts.merge(split_after(parts[:after]))
       end

--- a/lib/mediawiki/page.rb
+++ b/lib/mediawiki/page.rb
@@ -110,8 +110,8 @@ module MediaWiki
         end
       end
 
-      def matchdata_to_h(md)
-        md.names.map(&:to_sym).zip(md.captures).to_h
+      def matchdata_to_h(matchdata)
+        matchdata.names.map(&:to_sym).zip(matchdata.captures).to_h
       end
     end
   end

--- a/mediawiki-page-replaceable_content.gemspec
+++ b/mediawiki-page-replaceable_content.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|

--- a/test/mediawiki/page_test.rb
+++ b/test/mediawiki/page_test.rb
@@ -353,4 +353,14 @@ New content here!
       )
     end
   end
+
+  describe 'a page without the template' do
+    let(:wikitext) { 'no template here' }
+
+    it 'raises exception when replacing content' do
+      assert_raises MediaWiki::Page::ReplaceableContent::TemplateNotFoundError do
+        section.replace_output('New content')
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 require 'mediawiki/client'
 require 'mediawiki/page'
 


### PR DESCRIPTION
Instead of raising RuntimeError so this exception can be caught a dealt
with.

Will be useful to fix https://github.com/mysociety/verification-pages/issues/549